### PR TITLE
This commit introduces a new feature to the Morph plugin, allowing us…

### DIFF
--- a/Morph/Source/MorphAudioPlugin.cpp
+++ b/Morph/Source/MorphAudioPlugin.cpp
@@ -12,6 +12,11 @@ public:
         }
     }
     
+    AudioProcessorValueTreeState::ParameterLayout createParameterLayout() override
+    {
+        return MorphPluginParameters::createParameterLayout();
+    }
+
     ParameterContainerComponent * createUi(SpectralAudioPlugin *plugin) override {
         return new MorphSlider(m_params, Colour::fromString(TEXT_COLOUR), 30);
     }

--- a/Morph/Source/MorphInteractor.cpp
+++ b/Morph/Source/MorphInteractor.cpp
@@ -2,14 +2,30 @@
 #include "MorphFFTProcessor.h"
 #include "../../shared//utilities.h"
 
+MorphInteractor::MorphInteractor(int numOverlaps, std::shared_ptr<MorphPluginParameters> params) :
+    SpectralAudioProcessorInteractor(numOverlaps),
+    m_morphParams(params),
+    m_halfFftSize(0)
+{
+    params->setListener(this);
+    m_morphPointsChanged = false;
+
+    pReadArray = &pointsArray1;
+    pWriteArray = &pointsArray2;
+}
+
+void MorphInteractor::onFftSizeChanged()
+{
+    m_halfFftSize = this->getFftSize() / 2;
+}
+
 void MorphInteractor::prepareProcess(StandardFFTProcessor* spectralProcessor)
 {
     if(m_morphPointsChanged) {
         m_morphPointsChanged = false;
         std::swap(pReadArray, pWriteArray);
     }
-    // TODO: pre calc half size
-    else if(pReadArray->size() != (this->getFftSize() / 2 ))
+    else if(pReadArray->size() != m_halfFftSize)
     {
         m_morphParams->triggerControlPointsChanged();
     }
@@ -17,32 +33,41 @@ void MorphInteractor::prepareProcess(StandardFFTProcessor* spectralProcessor)
 
 std::unique_ptr<StandardFFTProcessor> MorphInteractor::createSpectralProcess(int index, int fftSize, int hopSize, int sampleRate, int numOverlaps, int chan, int numChans)
 {
-	return std::make_unique<MorphFFTProcessor>(fftSize, hopSize, hopSize * (index%numOverlaps), (int)sampleRate, this->getPhaseBuffer(), &pReadArray);
+    m_halfFftSize = fftSize / 2;
+    return std::make_unique<MorphFFTProcessor>(fftSize, hopSize, hopSize * (index%numOverlaps), (int)sampleRate, this->getPhaseBuffer(), &pReadArray);
 }
 
-void MorphInteractor::controlPointsChanged(Array<float> controlPoints) {
+void MorphInteractor::controlPointsChanged(const ControlPoints& controlPoints1, const ControlPoints& controlPoints2, float interpolation) {
     m_morphPointsChanged = false;
     
-    auto fftSize = this->getFftSize() / 2; // we are only mapping the real components so ignoring imaginary
+    auto audioValues1 = SplineHelper::getAudioSplineValues(controlPoints1);
+    auto audioValues2 = SplineHelper::getAudioSplineValues(controlPoints2);
+
+    if (audioValues1.isEmpty() || audioValues2.isEmpty()) {
+        return;
+    }
+
+    auto controlPoints = SplineHelper::interpolate(audioValues1, audioValues2, interpolation);
+
     auto controlPointsSize = controlPoints.size();
     
-    if(fftSize == 0 || controlPointsSize == 0) { return; }
-    if(fftSize == controlPointsSize) {
+    if(m_halfFftSize == 0 || controlPointsSize == 0) { return; }
+    if(m_halfFftSize == controlPointsSize) {
         
         Array<int> fftRangedControlPoints;
         for(int i=0; i<controlPointsSize; ++i) {
-            fftRangedControlPoints.add(controlPoints[i] * fftSize);
+            fftRangedControlPoints.add(controlPoints[i] * m_halfFftSize);
         }
         
         *pWriteArray = fftRangedControlPoints;
     }
-    else if(fftSize < controlPointsSize) {
-        auto skip = fftSize / controlPointsSize;
+    else if(m_halfFftSize < controlPointsSize) {
+        auto skip = m_halfFftSize / controlPointsSize;
         
         Array<int> compactedOutput;
         for(int i=0; i<controlPointsSize; i += skip) {
             float value = controlPoints[i];
-            compactedOutput.add(value * fftSize);
+            compactedOutput.add(value * m_halfFftSize);
         }
         
         *pWriteArray = compactedOutput;
@@ -50,20 +75,20 @@ void MorphInteractor::controlPointsChanged(Array<float> controlPoints) {
     else /* fftSize > controlPointSize */ {
         
         Array<int> expandedOutput;
-        auto indexScale = (float)controlPointsSize / (float)fftSize;
+        auto indexScale = (float)controlPointsSize / (float)m_halfFftSize;
         
-        for(int i=0; i<fftSize; ++i) {
+        for(int i=0; i<m_halfFftSize; ++i) {
             float controlPointIndex = (float)i * indexScale;
             int indA = (int)controlPointIndex;
             int indB = indA + 1;
             
             float aValue = controlPoints[indA];
             if(indB >= controlPointsSize) {
-                expandedOutput.add(aValue * fftSize);
+                expandedOutput.add(aValue * m_halfFftSize);
             } else {
                 float bValue = controlPoints[indB];
                 float value = utilities::interp_lin(aValue, bValue, controlPointIndex);
-                expandedOutput.add(value * fftSize);
+                expandedOutput.add(value * m_halfFftSize);
             }
         }
         

--- a/Morph/Source/MorphInteractor.h
+++ b/Morph/Source/MorphInteractor.h
@@ -4,20 +4,16 @@
 #include "../../shared/StandardFFTProcessor.h"
 #include "../../shared/SpectralAudioProcessorInteractor.h"
 #include "MorphPluginParameters.h"
+#include "../../shared/components/SplineHelper.h"
 
 class MorphInteractor : public SpectralAudioProcessorInteractor, MorphPluginParameters::Listener {
 public:
-	MorphInteractor(int numOverlaps, std::shared_ptr<MorphPluginParameters> params) : SpectralAudioProcessorInteractor(numOverlaps), m_morphParams(params) {		
-        params->setListener(this);
-        m_morphPointsChanged = false;
-        
-        pReadArray = &pointsArray1;
-        pWriteArray = &pointsArray2;
-	}
-		
-	void prepareProcess(StandardFFTProcessor* spectralProcessor) override;
-	std::unique_ptr<StandardFFTProcessor> createSpectralProcess(int index, int fftSize, int hopSize, int sampleRate, int numOverlaps, int chan, int numChans) override;
-    void controlPointsChanged(Array<float> controlPoints) override;
+    MorphInteractor(int numOverlaps, std::shared_ptr<MorphPluginParameters> params);
+
+    void prepareProcess(StandardFFTProcessor* spectralProcessor) override;
+    std::unique_ptr<StandardFFTProcessor> createSpectralProcess(int index, int fftSize, int hopSize, int sampleRate, int numOverlaps, int chan, int numChans) override;
+    void controlPointsChanged(const ControlPoints& controlPoints1, const ControlPoints& controlPoints2, float interpolation) override;
+    void onFftSizeChanged() override;
 
 private:
     juce::Array<int> pointsArray1;
@@ -28,4 +24,6 @@ private:
     bool m_morphPointsChanged;
     
     std::shared_ptr<MorphPluginParameters> m_morphParams;
+
+    int m_halfFftSize;
 };

--- a/Morph/Source/MorphPluginParameters.cpp
+++ b/Morph/Source/MorphPluginParameters.cpp
@@ -1,111 +1,136 @@
-/*
-  ==============================================================================
-    MorphPluginParameters.cpp
-  ==============================================================================
-*/
-
 #include "MorphPluginParameters.h"
 #include "MorphInteractor.h"
 #include "../../shared/components/SplineHelper.h"
 
+const Identifier MorphPluginParameters::pointTree1Id("pointTree1");
+const Identifier MorphPluginParameters::pointTree2Id("pointTree2");
+
 MorphPluginParameters::MorphPluginParameters(AudioProcessor * processor) :
-    PluginParameters(processor),    
-    didSetInitialAudioState(false),
-    controlPointComponent(nullptr)
-{}
+PluginParameters(processor),
+m_didSetInitialAudioState(false),
+m_controlPointComponent1(nullptr),
+m_controlPointComponent2(nullptr),
+m_listener(nullptr)
+{
+    m_interpolation = m_vts.getRawParameterValue(INTERPOLATION_ID);
+
+    m_vts.addParameterListener(INTERPOLATION_ID, this);
+}
+
+AudioProcessorValueTreeState::ParameterLayout MorphPluginParameters::createParameterLayout()
+{
+    std::vector<std::unique_ptr<RangedAudioParameter>> params;
+
+    params.push_back(std::make_unique<AudioParameterFloat>(INTERPOLATION_ID, INTERPOLATION_NAME, 0.0f, 1.0f, 0.0f));
+    
+    return { params.begin(), params.end() };
+}
+
+
+void MorphPluginParameters::parameterChanged(const String &parameterID, float newValue)
+{
+    triggerControlPointsChanged();
+}
 
 void MorphPluginParameters::controlPointsChanged(Array<float> controlPoints, ControlPointComponent* component) {
-    
-    lastPoints = component->getSourcePoints();
-    this->lastPointsV2.setPointsAndScale(component->getSourcePoints(), component->getBounds().getBottom());
+    if (component == m_controlPointComponent1) {
+        m_controlPoints1.setPointsAndScale(component->getSourcePoints(), component->getBounds().getBottom());
+    } else if (component == m_controlPointComponent2) {
+        m_controlPoints2.setPointsAndScale(component->getSourcePoints(), component->getBounds().getBottom());
+    }
     
     auto newState = copyState();
     PluginParameters::replaceState(newState);
     
-    if(listener != nullptr) {
-        listener->controlPointsChanged(controlPoints);
+    if(m_listener != nullptr) {
+        m_listener->controlPointsChanged(m_controlPoints1, m_controlPoints2, m_interpolation->load());
     }
 }
 
 void MorphPluginParameters::replaceState(const ValueTree& newState) {
     PluginParameters::replaceState(newState);
     
-    bool paramsEmptyBeforePopulate = this->lastPointsV2.isEmpty();
+    bool paramsEmptyBeforePopulate = m_controlPoints1.isEmpty() && m_controlPoints2.isEmpty();
     
-    setPointsFromState(newState, this->lastPointsV2);
-    if(!lastPointsV2.points.isEmpty() && controlPointComponent != nullptr) {
-        controlPointComponent->setSourcePoints(lastPointsV2.points);
+    setPointsFromState(newState, m_controlPoints1, pointTree1Id);
+    if(!m_controlPoints1.points.isEmpty() && m_controlPointComponent1 != nullptr) {
+        m_controlPointComponent1->setSourcePoints(m_controlPoints1.points);
     }
     
-    // TODO: this is an ugly hack because we are using replaceState internally thus we are using it in 2 places. We only want the below to run when called externaly
-    bool paramsDidChange = paramsEmptyBeforePopulate && !this->lastPointsV2.isEmpty();
-    if(!didSetInitialAudioState || paramsDidChange) {
-        didSetInitialAudioState = true;
+    setPointsFromState(newState, m_controlPoints2, pointTree2Id);
+    if(!m_controlPoints2.points.isEmpty() && m_controlPointComponent2 != nullptr) {
+        m_controlPointComponent2->setSourcePoints(m_controlPoints2.points);
+    }
+
+    bool paramsDidChange = paramsEmptyBeforePopulate && (!m_controlPoints1.isEmpty() || !m_controlPoints2.isEmpty());
+    if(!m_didSetInitialAudioState || paramsDidChange) {
+        m_didSetInitialAudioState = true;
         this->triggerControlPointsChanged();
     }
 }
 
 void MorphPluginParameters::triggerControlPointsChanged() {
-    if(listener != nullptr && !lastPointsV2.points.isEmpty()) {
-        auto audioValues = SplineHelper::getAudioSplineValues(lastPointsV2.points, lastPointsV2.yScale);
-        listener->controlPointsChanged(audioValues);
+    if(m_listener != nullptr && !m_controlPoints1.points.isEmpty() && !m_controlPoints2.points.isEmpty()) {
+        m_listener->controlPointsChanged(m_controlPoints1, m_controlPoints2, m_interpolation->load());
     };
 }
 
 ValueTree MorphPluginParameters::copyState() {
     ValueTree tree = PluginParameters::copyState();
     
-    if (tree.getChildWithName("pointTree").isValid()) {
-        tree.removeChild(tree.getChildWithName("pointTree"), nullptr);
+    if (tree.getChildWithName(pointTree1Id).isValid()) {
+        tree.removeChild(tree.getChildWithName(pointTree1Id), nullptr);
     }
     
-    ValueTree pointTree("pointTree");
-    
-    auto points = lastPointsV2.points;
-    if(points.isEmpty()) {
-        return tree;
+    if (tree.getChildWithName(pointTree2Id).isValid()) {
+        tree.removeChild(tree.getChildWithName(pointTree2Id), nullptr);
     }
     
-    pointTree.setProperty("ylimit", lastPointsV2.yScale, nullptr);
-    
-    for(auto& point : points) {
-        ValueTree valuePoint ("point");
-        valuePoint.setProperty("x", point.x, nullptr);
-        valuePoint.setProperty("y", point.y, nullptr);
-        pointTree.appendChild(valuePoint, nullptr);
+    auto pointTree1 = SplineHelper::pointsToValueTree(m_controlPoints1, pointTree1Id);
+    if(pointTree1.isValid()) {
+        tree.addChild(pointTree1, -1, nullptr);
     }
     
-    tree.addChild(pointTree, -1, nullptr);
+    auto pointTree2 = SplineHelper::pointsToValueTree(m_controlPoints2, pointTree2Id);
+    if(pointTree2.isValid()) {
+        tree.addChild(pointTree2, -1, nullptr);
+    }
     
     return tree;
 }
 
-void MorphPluginParameters::setControlPointComponent(ControlPointComponent* component) {
-    component->setListener(this);
-    this->controlPointComponent = component;
-    this->setPointsFromState(getState(), this->lastPointsV2);
+void MorphPluginParameters::setControlPointComponents(ControlPointComponent* component1, ControlPointComponent* component2) {
+    component1->setListener(this);
+    m_controlPointComponent1 = component1;
+    setPointsFromState(getState(), m_controlPoints1, pointTree1Id);
+
+    if(!m_controlPoints1.points.isEmpty()) {
+        component1->setSourcePoints(m_controlPoints1.points);
+    }
+
+    component2->setListener(this);
+    m_controlPointComponent2 = component2;
+    setPointsFromState(getState(), m_controlPoints2, pointTree2Id);
     
-    if(!lastPointsV2.points.isEmpty()) {
-        component->setSourcePoints(lastPointsV2.points);
+    if(!m_controlPoints2.points.isEmpty()) {
+        component2->setSourcePoints(m_controlPoints2.points);
     }
 }
 
-void MorphPluginParameters::setPointsFromState(ValueTree state, ControlPoints &controlPoints) {
-    auto xmlStr = state.toXmlString();
-    if(!state.getChildWithName("pointTree").isValid()) {
+void MorphPluginParameters::setPointsFromState(const ValueTree& state, ControlPoints &controlPoints, const Identifier& pointTreeId) {
+    auto pointTree = state.getChildWithName(pointTreeId);
+    if(!pointTree.isValid()) {
         controlPoints.clear();
         return;
     }
-    
-    auto pointTree = state.getChildWithName("pointTree");
     
     int yLimit;
     if (pointTree.hasProperty("ylimit"))
     {
         yLimit = pointTree.getPropertyAsValue("ylimit", nullptr).getValue();
     }
-    else if(controlPointComponent != nullptr) {
-        yLimit = controlPointComponent->getLocalBounds().getBottom();
+    else if(m_controlPointComponent1 != nullptr) {
+        yLimit = m_controlPointComponent1->getLocalBounds().getBottom();
     }
     else {
         controlPoints.clear();
@@ -126,8 +151,4 @@ void MorphPluginParameters::setPointsFromState(ValueTree state, ControlPoints &c
     }
     
     controlPoints.setPointsAndScale(points, yLimit);
-}
-
-void MorphPluginParameters::setAudioMorphPointsOnState(Array<float> audioMorphPoints, ValueTree state) {
-    
 }

--- a/Morph/Source/MorphPluginParameters.h
+++ b/Morph/Source/MorphPluginParameters.h
@@ -4,6 +4,11 @@
 #include "../../shared/components/ControlPointComponent.h"
 #include "ControlPoints.h"
 
+#include <atomic>
+
+#define INTERPOLATION_ID "interpolation"
+#define INTERPOLATION_NAME "Interpolation"
+
 class MorphInteractor;
 
 class MorphPluginParameters : public PluginParameters, public ControlPointComponent::Listener {
@@ -11,34 +16,36 @@ public:
     class Listener {
     public:
         virtual ~Listener() = default;
-        virtual void controlPointsChanged(Array<float> controlPoints) = 0;
+        virtual void controlPointsChanged(const ControlPoints& controlPoints1, const ControlPoints& controlPoints2, float interpolation) = 0;
     };
-        
-	MorphPluginParameters(AudioProcessor* processor);
+
+    MorphPluginParameters(AudioProcessor* processor);
+
+    static AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
     
     void replaceState(const ValueTree& newState) override;
-    ValueTree copyState() override;    	
-		
+    ValueTree copyState() override;
+
     void setListener(Listener* listener){this->listener = listener;}
-    void setControlPointComponent(ControlPointComponent* component);
+    void setControlPointComponents(ControlPointComponent* component1, ControlPointComponent* component2);
     void triggerControlPointsChanged();
-    Array<juce::Point<int>> getLastPoints() const { return lastPoints; }
     
     void controlPointsChanged (Array<float> controlPoints, ControlPointComponent* component) override;
+    
+    const ControlPoints& getControlPoints1() const { return m_controlPoints1; }
+    const ControlPoints& getControlPoints2() const { return m_controlPoints2; }
+
 private:
-    void setPointsFromState(ValueTree state, ControlPoints &controlPoints);
-    void setAudioMorphPointsOnState(Array<float> audioMorphPoints, ValueTree state);
+    void setPointsFromState(const ValueTree& state, ControlPoints &controlPoints, const Identifier& pointTreeId);
     
-    // TODO: this is an awfully named variable
-    Array<juce::Point<int>> lastPoints;
+    ControlPoints m_controlPoints1;
+    ControlPoints m_controlPoints2;
     
-    // TODO: use a unique pointer instead?
-    ControlPoints lastPointsV2;
+    Listener* m_listener;
+    bool m_didSetInitialAudioState;
     
+    ControlPointComponent* m_controlPointComponent1;
+    ControlPointComponent* m_controlPointComponent2;
     
-    Listener* listener;
-    bool didSetInitialAudioState;
-    
-    // TODO: this should really not be here. It is only here to query and set the parameters
-    ControlPointComponent* controlPointComponent;
+    std::atomic<float>* m_interpolation;
 };

--- a/Morph/Source/MorphSlider.cpp
+++ b/Morph/Source/MorphSlider.cpp
@@ -1,12 +1,18 @@
 #include "../JuceLibraryCode/JuceHeader.h"
 #include "MorphSlider.h"
 
-//==============================================================================
 MorphSlider::MorphSlider(std::shared_ptr<MorphPluginParameters> valueTreeState, Colour textColour, int textBoxHeight)
 {
-    this->addAndMakeVisible(controlPointComponent);
-	this->valueTreeState = valueTreeState;
-    this->valueTreeState.get()->setControlPointComponent(&this->controlPointComponent);
+    m_pluginParameters = valueTreeState;
+
+    addAndMakeVisible(m_controlPointComponent1);
+    addAndMakeVisible(m_controlPointComponent2);
+
+    m_pluginParameters->setControlPointComponents(&m_controlPointComponent1, &m_controlPointComponent2);
+
+    addAndMakeVisible(m_interpolationSlider);
+    m_interpolationSlider.setSliderStyle(Slider::SliderStyle::LinearHorizontal);
+    m_interpolationAttachment = std::make_unique<AudioProcessorValueTreeState::SliderAttachment>(m_pluginParameters->getVts(), INTERPOLATION_ID, m_interpolationSlider);
 }
 
 MorphSlider::~MorphSlider()
@@ -15,12 +21,11 @@ MorphSlider::~MorphSlider()
 
 void MorphSlider::paint(Graphics& g)
 {
-	g.fillAll(Colours::white); 
+    g.fillAll(Colours::white);
 }
 
 void MorphSlider::resized()
 {
-
     InitialPoint p1(0.0, 1.0);
     p1.lockX = true;
     p1.lockY = true;
@@ -30,12 +35,24 @@ void MorphSlider::resized()
     p2.lockY = true;
     
     Array<InitialPoint> initialPoints(p1, p2);
-        
-    controlPointComponent.setInitialPoints(initialPoints);
-    auto lastPoints = this->valueTreeState->getLastPoints();
-    if(!lastPoints.isEmpty()) {
-        controlPointComponent.setSourcePoints(lastPoints);
+
+    m_controlPointComponent1.setInitialPoints(initialPoints);
+    auto lastPoints1 = m_pluginParameters->getControlPoints1();
+    if(!lastPoints1.points.isEmpty()) {
+        m_controlPointComponent1.setSourcePoints(lastPoints1.points);
     }
     
-    controlPointComponent.setBounds(0, 0, getWidth() * 0.8, getHeight());
+    m_controlPointComponent2.setInitialPoints(initialPoints);
+    auto lastPoints2 = m_pluginParameters->getControlPoints2();
+    if(!lastPoints2.points.isEmpty()) {
+        m_controlPointComponent2.setSourcePoints(lastPoints2.points);
+    }
+
+    auto bounds = getLocalBounds();
+    auto graphWidth = bounds.getWidth() * 0.8;
+
+    m_controlPointComponent1.setBounds(0, 0, graphWidth, bounds.getHeight() / 2);
+    m_controlPointComponent2.setBounds(0, bounds.getHeight() / 2, graphWidth, bounds.getHeight() / 2);
+
+    m_interpolationSlider.setBounds(graphWidth, 0, 30, bounds.getHeight());
 }

--- a/Morph/Source/MorphSlider.h
+++ b/Morph/Source/MorphSlider.h
@@ -6,25 +6,29 @@
 #include "../../shared/ParameterContainerComponent.h"
 #include "../../shared/components/ControlPointComponent.h"
 
-//==============================================================================
-class MorphSlider : public ParameterContainerComponent	
+class MorphSlider : public ParameterContainerComponent
 {
 public:
     MorphSlider(std::shared_ptr<MorphPluginParameters> valueTreeState, Colour textColour, int textBoxHeight);
     ~MorphSlider();
 
     void paint (Graphics&) override;
-    void resized() override;	
-					
-    std::shared_ptr<PluginParameters> getPluginParameters() override { return valueTreeState; }
-    const int getComponentHeight() override { return 120; }
+    void resized() override;
+
+    std::shared_ptr<PluginParameters> getPluginParameters() override { return m_pluginParameters; }
+    const int getComponentHeight() override { return 240; }
     void onFftSizeChanged() override {
-        controlPointComponent.notifyChanged();
+        m_controlPointComponent1.notifyChanged();
+        m_controlPointComponent2.notifyChanged();
     }
 
 private:
-	std::shared_ptr<MorphPluginParameters> valueTreeState;
-    ControlPointComponent controlPointComponent;
+    std::shared_ptr<MorphPluginParameters> m_pluginParameters;
+    ControlPointComponent m_controlPointComponent1;
+    ControlPointComponent m_controlPointComponent2;
+
+    Slider m_interpolationSlider;
+    std::unique_ptr<AudioProcessorValueTreeState::SliderAttachment> m_interpolationAttachment;
     
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MorphSlider)	
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MorphSlider)
 };

--- a/shared/components/SplineHelper.cpp
+++ b/shared/components/SplineHelper.cpp
@@ -1,32 +1,22 @@
-/*
- ==============================================================================
- 
- SplineHelper.cpp
- Created: 28 Aug 2023 6:02:16pm
- Author:  Andrew Reeman
- 
- ==============================================================================
- */
-
 #include "SplineHelper.h"
 #include "Spline.h"
 
 namespace SplineHelper {
-Array<float> getAudioSplineValues(Array<juce::Point<int>> points, float yLimit) {
+Array<float> getAudioSplineValues(const ControlPoints& controlPoints) {
     Array<float> outputValues;
     
-    if(points.size() < 2) { return outputValues; }
+    if(controlPoints.points.size() < 2) { return outputValues; }
     
     const int resolution = 128;
-    auto pStart = points.getFirst();
-    auto pEnd = points.getLast();
+    auto pStart = controlPoints.points.getFirst();
+    auto pEnd = controlPoints.points.getLast();
     
     int xRange = pEnd.x - pStart.x;
     float increment = (float)xRange / (float)resolution;
     
     Array<juce::Point<double>> dpoints;
-    if (points.size() >= 3) {
-        for (auto p : points)
+    if (controlPoints.points.size() >= 3) {
+        for (auto p : controlPoints.points)
             dpoints.add ({ double (p.getX()), double (p.getY())});
     }
     else {
@@ -43,10 +33,10 @@ Array<float> getAudioSplineValues(Array<juce::Point<int>> points, float yLimit) 
     
     outputValues.clearQuick();
     Spline spline (dpoints);
-    double bottom = (double)yLimit;
+    double bottom = (double)controlPoints.yScale;
     if(bottom == 0) { return outputValues; }
     
-    for (float x = (float)points.getFirst().getX(); x < (float)points.getLast().getX(); x += increment)
+    for (float x = (float)controlPoints.points.getFirst().getX(); x < (float)controlPoints.points.getLast().getX(); x += increment)
     {
         if(outputValues.size() >= resolution) {
             break;
@@ -64,6 +54,38 @@ Array<float> getAudioSplineValues(Array<juce::Point<int>> points, float yLimit) 
     }
     
     return outputValues;
+}
+
+ValueTree pointsToValueTree(const ControlPoints& controlPoints, const Identifier& pointTreeId)
+{
+    if(controlPoints.points.isEmpty()) {
+        return ValueTree();
+    }
+
+    ValueTree pointTree(pointTreeId);
+    pointTree.setProperty("ylimit", controlPoints.yScale, nullptr);
+
+    for(auto& point : controlPoints.points) {
+        ValueTree valuePoint ("point");
+        valuePoint.setProperty("x", point.x, nullptr);
+        valuePoint.setProperty("y", point.y, nullptr);
+        pointTree.appendChild(valuePoint, nullptr);
+    }
+
+    return pointTree;
+}
+
+Array<float> interpolate(const Array<float>& array1, const Array<float>& array2, float mix)
+{
+    Array<float> result;
+
+    jassert(array1.size() == array2.size());
+
+    for (int i = 0; i < array1.size(); ++i) {
+        result.add(jmap(mix, array1[i], array2[i]));
+    }
+
+    return result;
 }
 
 }

--- a/shared/components/SplineHelper.h
+++ b/shared/components/SplineHelper.h
@@ -1,17 +1,10 @@
-/*
-  ==============================================================================
-
-    SplineHelper.h
-    Created: 28 Aug 2023 6:02:16pm
-    Author:  Andrew Reeman
-
-  ==============================================================================
-*/
-
 #pragma once
 
 #include "../JuceLibraryCode/JuceHeader.h"
+#include "../../Morph/Source/ControlPoints.h"
 
 namespace SplineHelper {
-    Array<float> getAudioSplineValues(Array<juce::Point<int>> points, float yLimit);
+    Array<float> getAudioSplineValues(const ControlPoints& controlPoints);
+    ValueTree pointsToValueTree(const ControlPoints& controlPoints, const Identifier& pointTreeId);
+    Array<float> interpolate(const Array<float>& array1, const Array<float>& array2, float mix);
 }


### PR DESCRIPTION
Key changes include:
- Added a second `ControlPointComponent` to the UI, enabling two separate morph graphs.
- Introduced a new "Interpolation" slider, which is automatable in a DAW, to control the mix between the two graphs.
- Updated `MorphInteractor` to interpolate between the two spectral shapes based on the slider's value.
- Modified the plugin's state management to save and load both sets of control points.
- Refactored `SplineHelper` to support the new interpolation logic and improve code organization.